### PR TITLE
feat: add daily + term backtesting CLI and expanded indicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ build/
 .yarn/install-state.gz
 node_modules/
 package-lock.json
+
+data/backtests/

--- a/src/truthbrush_oil_study/backtest.py
+++ b/src/truthbrush_oil_study/backtest.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from datetime import datetime, timezone
+from html import unescape
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+import pandas as pd
+import statsmodels.api as sm
+from scipy.stats import ttest_ind
+
+from .indicators import extract_indicators
+from .truth_social import parse_trumpstruth_homepage
+
+SYMBOLS = {"WTI": "CL=F", "Brent": "BZ=F"}
+
+
+def _fetch_html(url: str, attempts: int = 3) -> str:
+    last_error: Exception | None = None
+    for i in range(attempts):
+        try:
+            req = Request(url, headers={"User-Agent": "Mozilla/5.0"})
+            with urlopen(req, timeout=30) as response:
+                return response.read().decode("utf-8", "replace")
+        except Exception as exc:  # pragma: no cover - network volatility
+            last_error = exc
+            time.sleep(1.0 + i)
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("failed to fetch html")
+
+
+def _collect_posts(max_pages: int) -> list:
+    next_url = "https://trumpstruth.org/"
+    seen_urls: set[str] = set()
+    posts_by_id: dict[str, object] = {}
+
+    for _ in range(max_pages):
+        if not next_url or next_url in seen_urls:
+            break
+        seen_urls.add(next_url)
+
+        html_text = _fetch_html(next_url)
+        parsed = parse_trumpstruth_homepage(html_text, limit=None)
+        for post in parsed:
+            text = (post.text or "").strip()
+            if not text or "Removed from Truth Social" in text:
+                continue
+            posts_by_id[post.id] = post
+
+        match = re.search(r'href="([^"]+)"[^>]*>\s*Next Page\s*<', html_text, re.I)
+        next_url = unescape(match.group(1)) if match else None
+
+    return sorted(posts_by_id.values(), key=lambda p: p.created_at)
+
+
+def _fetch_daily_prices(symbol: str, range_: str = "2y") -> pd.DataFrame:
+    url = f"https://query1.finance.yahoo.com/v8/finance/chart/{symbol}?interval=1d&range={range_}"
+    req = Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urlopen(req, timeout=30) as response:
+        payload = json.loads(response.read().decode())
+
+    result = payload["chart"]["result"][0]
+    timestamps = result.get("timestamp") or []
+    closes = result["indicators"]["quote"][0].get("close") or []
+
+    rows = []
+    for ts, close in zip(timestamps, closes):
+        if close is None:
+            continue
+        date = pd.Timestamp(ts, unit="s", tz="UTC").normalize().date()
+        rows.append({"date_utc": date, "close": float(close)})
+
+    df = pd.DataFrame(rows).sort_values("date_utc").drop_duplicates("date_utc").reset_index(drop=True)
+    df["return_1d"] = df["close"].pct_change()
+    df["abs_return_1d"] = df["return_1d"].abs()
+    df["next_return_1d"] = df["return_1d"].shift(-1)
+    df["next_abs_return_1d"] = df["abs_return_1d"].shift(-1)
+    return df
+
+
+def _fit_models(df: pd.DataFrame, instrument: str, subset: str) -> tuple[dict, list[dict]]:
+    y = df["next_abs_return_1d"]
+
+    base_terms = ["post_count", "max_war_score", "max_oil_score", "max_urgency", "avg_sentiment"]
+    expanded_terms = base_terms + [
+        "max_chokepoint_score",
+        "max_kinetic_score",
+        "max_policy_score",
+        "max_execution_score",
+    ]
+
+    x_base = sm.add_constant(df[base_terms], has_constant="add")
+    x_expanded = sm.add_constant(df[expanded_terms], has_constant="add")
+
+    model_base = sm.OLS(y, x_base).fit()
+    model_expanded = sm.OLS(y, x_expanded).fit()
+
+    summary = {
+        "instrument": instrument,
+        "subset": subset,
+        "n_obs": int(model_base.nobs),
+        "base_r2": model_base.rsquared,
+        "base_adj_r2": model_base.rsquared_adj,
+        "base_aic": model_base.aic,
+        "expanded_r2": model_expanded.rsquared,
+        "expanded_adj_r2": model_expanded.rsquared_adj,
+        "expanded_aic": model_expanded.aic,
+        "delta_adj_r2": model_expanded.rsquared_adj - model_base.rsquared_adj,
+        "delta_aic": model_expanded.aic - model_base.aic,
+    }
+
+    coef_rows: list[dict] = []
+    for term in ["const", *expanded_terms]:
+        coef_rows.append(
+            {
+                "instrument": instrument,
+                "subset": subset,
+                "term": term,
+                "coef": model_expanded.params.get(term, float("nan")),
+                "p_value": model_expanded.pvalues.get(term, float("nan")),
+            }
+        )
+
+    return summary, coef_rows
+
+
+def run_daily_backtest(*, max_pages: int = 60, output_dir: Path | None = None) -> dict:
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    out_dir = output_dir or (Path("data/backtests") / run_id)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    posts = _collect_posts(max_pages=max_pages)
+    if not posts:
+        raise RuntimeError("No posts collected from trumpstruth.org")
+
+    post_rows = []
+    for post in posts:
+        indicators = extract_indicators(post.text)
+        post_rows.append(
+            {
+                "post_id": post.id,
+                "ts_utc": pd.Timestamp(post.created_at),
+                "date_utc": pd.Timestamp(post.created_at).date(),
+                "text": post.text,
+                "actionability": indicators["actionability"],
+                "war_escalation_score": indicators["war_escalation_score"],
+                "oil_supply_risk_score": indicators["oil_supply_risk_score"],
+                "sanctions_score": indicators["sanctions_score"],
+                "urgency_score": indicators["urgency_score"],
+                "sentiment_score": indicators["sentiment_score"],
+                "chokepoint_risk_score": indicators["chokepoint_risk_score"],
+                "kinetic_action_score": indicators["kinetic_action_score"],
+                "policy_mechanism_score": indicators["policy_mechanism_score"],
+                "execution_certainty_score": indicators["execution_certainty_score"],
+            }
+        )
+
+    posts_df = pd.DataFrame(post_rows)
+
+    features = (
+        posts_df.groupby("date_utc", as_index=False)
+        .agg(
+            post_count=("post_id", "size"),
+            high_actionability_count=("actionability", lambda s: int((s == "high").sum())),
+            max_war_score=("war_escalation_score", "max"),
+            max_oil_score=("oil_supply_risk_score", "max"),
+            max_urgency=("urgency_score", "max"),
+            avg_sentiment=("sentiment_score", "mean"),
+            max_chokepoint_score=("chokepoint_risk_score", "max"),
+            max_kinetic_score=("kinetic_action_score", "max"),
+            max_policy_score=("policy_mechanism_score", "max"),
+            max_execution_score=("execution_certainty_score", "max"),
+        )
+        .sort_values("date_utc")
+    )
+
+    features["has_post"] = (features["post_count"] > 0).astype(int)
+    features["has_high_actionability"] = (features["high_actionability_count"] > 0).astype(int)
+
+    model_summaries: list[dict] = []
+    coefficient_rows: list[dict] = []
+    hi_comparison_rows: list[dict] = []
+
+    for instrument, symbol in SYMBOLS.items():
+        prices = _fetch_daily_prices(symbol)
+        merged = prices.merge(features, on="date_utc", how="left")
+
+        fill_zero_columns = [
+            "post_count",
+            "high_actionability_count",
+            "max_war_score",
+            "max_oil_score",
+            "max_urgency",
+            "avg_sentiment",
+            "max_chokepoint_score",
+            "max_kinetic_score",
+            "max_policy_score",
+            "max_execution_score",
+            "has_post",
+            "has_high_actionability",
+        ]
+        for column in fill_zero_columns:
+            merged[column] = merged[column].fillna(0)
+
+        full = merged.dropna(subset=["next_abs_return_1d"]).copy()
+        window = full[
+            (full["date_utc"] >= features["date_utc"].min())
+            & (full["date_utc"] <= features["date_utc"].max())
+        ].copy()
+
+        for subset_name, subset_df in [("full", full), ("post_window", window)]:
+            if len(subset_df) < 20:
+                continue
+            summary, coef_rows = _fit_models(subset_df, instrument, subset_name)
+            model_summaries.append(summary)
+            coefficient_rows.extend(coef_rows)
+
+        hi = window[window["has_high_actionability"] == 1]["next_abs_return_1d"]
+        lo = window[window["has_high_actionability"] == 0]["next_abs_return_1d"]
+        t_stat = float("nan")
+        p_value = float("nan")
+        if len(hi) >= 2 and len(lo) >= 2:
+            t_stat, p_value = ttest_ind(hi, lo, equal_var=False, nan_policy="omit")
+
+        hi_comparison_rows.append(
+            {
+                "instrument": instrument,
+                "n_hi_days": len(hi),
+                "n_non_hi_days": len(lo),
+                "mean_next_abs_return_hi": hi.mean() if len(hi) else float("nan"),
+                "mean_next_abs_return_non_hi": lo.mean() if len(lo) else float("nan"),
+                "delta_hi_minus_non_hi": (hi.mean() - lo.mean()) if len(hi) and len(lo) else float("nan"),
+                "welch_t_stat": t_stat,
+                "welch_p_value": p_value,
+            }
+        )
+
+        merged.to_csv(out_dir / f"{instrument.lower()}_daily_merged.csv", index=False)
+
+    model_df = pd.DataFrame(model_summaries)
+    coef_df = pd.DataFrame(coefficient_rows)
+    hi_df = pd.DataFrame(hi_comparison_rows)
+
+    posts_df.to_csv(out_dir / "posts_with_indicators.csv", index=False)
+    features.to_csv(out_dir / "daily_post_features.csv", index=False)
+    model_df.to_csv(out_dir / "model_comparison.csv", index=False)
+    coef_df.to_csv(out_dir / "expanded_model_coefficients.csv", index=False)
+    hi_df.to_csv(out_dir / "high_actionability_comparison_post_window.csv", index=False)
+
+    summary = {
+        "run_id": run_id,
+        "output_dir": str(out_dir),
+        "posts": int(len(posts_df)),
+        "days_with_posts": int(len(features)),
+        "post_span_start": str(posts_df["ts_utc"].min()),
+        "post_span_end": str(posts_df["ts_utc"].max()),
+    }
+
+    (out_dir / "SUMMARY.txt").write_text(json.dumps(summary, indent=2))
+    return summary
+
+
+_TERM_STOPWORDS = {
+    "about", "after", "again", "against", "also", "among", "and", "any", "are", "around",
+    "because", "been", "before", "being", "below", "between", "both", "but", "can", "could",
+    "during", "each", "few", "from", "further", "have", "having", "here", "into", "its",
+    "itself", "just", "more", "most", "much", "must", "near", "only", "other", "over",
+    "own", "same", "should", "some", "such", "than", "that", "their", "theirs", "them",
+    "then", "there", "these", "they", "this", "those", "through", "under", "until", "very",
+    "what", "when", "where", "which", "while", "with", "would", "your", "yours", "president",
+    "thank", "attention", "matter",
+}
+
+
+def _extract_terms(text: str) -> set[str]:
+    terms = set()
+    for token in re.findall(r"[a-zA-Z']+", (text or "").lower()):
+        if len(token) < 4:
+            continue
+        if token in _TERM_STOPWORDS:
+            continue
+        terms.add(token)
+    return terms
+
+
+def run_term_indicator_scan(
+    *,
+    output_dir: Path,
+    min_term_days: int = 4,
+    min_non_term_days: int = 30,
+) -> dict:
+    posts_path = output_dir / "posts_with_indicators.csv"
+    wti_path = output_dir / "wti_daily_merged.csv"
+    brent_path = output_dir / "brent_daily_merged.csv"
+
+    if not posts_path.exists():
+        raise FileNotFoundError(f"Missing required file: {posts_path}")
+    if not wti_path.exists() or not brent_path.exists():
+        raise FileNotFoundError("Missing merged daily files for WTI/Brent")
+
+    posts = pd.read_csv(posts_path)
+    if "date_utc" not in posts.columns or "text" not in posts.columns:
+        raise ValueError("posts_with_indicators.csv must contain date_utc and text")
+
+    posts["date_utc"] = pd.to_datetime(posts["date_utc"]).dt.date
+    posts["text"] = posts["text"].fillna("")
+
+    term_days: dict[str, set] = {}
+    for day, group in posts.groupby("date_utc"):
+        day_terms: set[str] = set()
+        for txt in group["text"]:
+            day_terms |= _extract_terms(str(txt))
+        for term in day_terms:
+            term_days.setdefault(term, set()).add(day)
+
+    term_days = {t: ds for t, ds in term_days.items() if len(ds) >= min_term_days}
+
+    markets = {
+        "WTI": pd.read_csv(wti_path),
+        "Brent": pd.read_csv(brent_path),
+    }
+
+    per_market_rows: list[dict] = []
+    for instrument, market_df in markets.items():
+        if "date_utc" not in market_df.columns or "next_abs_return_1d" not in market_df.columns:
+            raise ValueError(f"{instrument} merged file missing required columns")
+        market_df["date_utc"] = pd.to_datetime(market_df["date_utc"]).dt.date
+        market_df = market_df.dropna(subset=["next_abs_return_1d"])
+
+        for term, days in term_days.items():
+            yes = market_df[market_df["date_utc"].isin(days)]["next_abs_return_1d"]
+            no = market_df[~market_df["date_utc"].isin(days)]["next_abs_return_1d"]
+
+            if len(yes) < min_term_days or len(no) < min_non_term_days:
+                continue
+
+            t_stat, p_value = ttest_ind(yes, no, equal_var=False, nan_policy="omit")
+            per_market_rows.append(
+                {
+                    "term": term,
+                    "instrument": instrument,
+                    "n_term_days": int(len(yes)),
+                    "n_non_term_days": int(len(no)),
+                    "mean_term": float(yes.mean()),
+                    "mean_non_term": float(no.mean()),
+                    "delta": float(yes.mean() - no.mean()),
+                    "welch_t_stat": float(t_stat),
+                    "p_value": float(p_value),
+                }
+            )
+
+    market_df = pd.DataFrame(per_market_rows)
+    if market_df.empty:
+        out_path = output_dir / "term_indicator_candidates.csv"
+        pd.DataFrame(
+            columns=[
+                "term",
+                "days_wti",
+                "days_brent",
+                "delta_wti",
+                "delta_brent",
+                "avg_delta",
+                "max_p",
+            ]
+        ).to_csv(out_path, index=False)
+        return {"output_dir": str(output_dir), "rows": 0, "top_term": None, "path": str(out_path)}
+
+    combined_rows: list[dict] = []
+    for term, group in market_df.groupby("term"):
+        if set(group["instrument"]) != {"WTI", "Brent"}:
+            continue
+        g = group.set_index("instrument")
+        combined_rows.append(
+            {
+                "term": term,
+                "days_wti": int(g.loc["WTI", "n_term_days"]),
+                "days_brent": int(g.loc["Brent", "n_term_days"]),
+                "delta_wti": float(g.loc["WTI", "delta"]),
+                "delta_brent": float(g.loc["Brent", "delta"]),
+                "avg_delta": float((g.loc["WTI", "delta"] + g.loc["Brent", "delta"]) / 2.0),
+                "max_p": float(max(g.loc["WTI", "p_value"], g.loc["Brent", "p_value"])),
+            }
+        )
+
+    combined = pd.DataFrame(combined_rows).sort_values(["avg_delta", "max_p"], ascending=[False, True])
+    out_path = output_dir / "term_indicator_candidates.csv"
+    combined.to_csv(out_path, index=False)
+
+    top_term = combined.iloc[0]["term"] if not combined.empty else None
+    return {
+        "output_dir": str(output_dir),
+        "rows": int(len(combined)),
+        "top_term": top_term,
+        "path": str(out_path),
+    }

--- a/src/truthbrush_oil_study/cli.py
+++ b/src/truthbrush_oil_study/cli.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 import typer
 
+from .backtest import run_daily_backtest, run_term_indicator_scan
+from .indicators import extract_indicators
 from .report import summarize_event_study
+from .topics import classify_post_topic
+from .truth_social import fetch_trumpstruth_posts
 
 app = typer.Typer(add_completion=False, help="Truth Social vs oil futures analysis pipeline")
 
@@ -20,6 +24,48 @@ def report(input_path: Path, output_path: Path | None = None) -> None:
     if output_path is not None:
         summary.to_csv(output_path, index=False)
     typer.echo(json.dumps(summary.to_dict(orient="records"), default=str))
+
+
+@app.command()
+def signals(limit: int = 5) -> None:
+    """Fetch latest trumpstruth posts and emit topic + indicator JSON records."""
+    posts = fetch_trumpstruth_posts(limit=limit)
+    payload = []
+    for post in posts:
+        indicators = extract_indicators(post.text)
+        payload.append(
+            {
+                "id": post.id,
+                "created_at": post.created_at.isoformat(),
+                "url": post.url,
+                "topic": classify_post_topic(post.text),
+                **indicators,
+                "text": post.text,
+            }
+        )
+    typer.echo(json.dumps(payload, default=str))
+
+
+@app.command("backtest-daily")
+def backtest_daily(max_pages: int = 60, output_dir: Path | None = None) -> None:
+    """Run daily volatility backtest and write artifacts to disk."""
+    summary = run_daily_backtest(max_pages=max_pages, output_dir=output_dir)
+    typer.echo(json.dumps(summary, default=str))
+
+
+@app.command("backtest-terms")
+def backtest_terms(
+    output_dir: Path = typer.Option(..., help="Existing backtest output directory"),
+    min_term_days: int = 4,
+    min_non_term_days: int = 30,
+) -> None:
+    """Rank terms by next-day volatility lift using an existing backtest output dir."""
+    summary = run_term_indicator_scan(
+        output_dir=output_dir,
+        min_term_days=min_term_days,
+        min_non_term_days=min_non_term_days,
+    )
+    typer.echo(json.dumps(summary, default=str))
 
 
 def main() -> int:

--- a/src/truthbrush_oil_study/indicators.py
+++ b/src/truthbrush_oil_study/indicators.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+POSITIVE_TERMS = {
+    "great",
+    "successful",
+    "success",
+    "strong",
+    "peace",
+    "win",
+    "winning",
+    "good",
+}
+
+NEGATIVE_TERMS = {
+    "disaster",
+    "crisis",
+    "failure",
+    "weak",
+    "threat",
+    "chaos",
+    "catastrophe",
+    "war",
+}
+
+WAR_ESCALATION_TERMS = {
+    "blockade",
+    "strike",
+    "eliminated",
+    "eliminate",
+    "navy",
+    "naval",
+    "ships",
+    "missile",
+    "attack",
+    "military",
+    "hormuz",
+}
+
+OIL_SUPPLY_RISK_TERMS = {
+    "hormuz",
+    "blockade",
+    "ports",
+    "port",
+    "ocean",
+    "sea",
+    "oil",
+    "tanker",
+    "shipping",
+    "exports",
+}
+
+SANCTIONS_TERMS = {
+    "sanctions",
+    "sanction",
+    "embargo",
+    "export controls",
+    "tariffs",
+    "penalties",
+}
+
+CHOKEPOINT_TERMS = {
+    "hormuz",
+    "strait",
+    "shipping lane",
+    "shipping lanes",
+    "tanker",
+    "tankers",
+    "port",
+    "ports",
+    "blockade",
+    "chokepoint",
+}
+
+KINETIC_ACTION_TERMS = {
+    "strike",
+    "strikes",
+    "missile",
+    "bomb",
+    "attack",
+    "intercept",
+    "destroy",
+    "eliminate",
+    "eliminated",
+    "naval",
+    "military",
+}
+
+POLICY_MECHANISM_TERMS = {
+    "sanctions",
+    "embargo",
+    "tariffs",
+    "export controls",
+    "executive order",
+    "order",
+    "ban",
+    "restriction",
+    "restrictions",
+    "seizure",
+}
+
+EXECUTION_CERTAINTY_TERMS = {
+    "effective immediately",
+    "will",
+    "will be",
+    "begin",
+    "begins",
+    "starting",
+    "tomorrow",
+    "at ",
+    "deadline",
+}
+
+URGENCY_TERMS = {
+    "immediate",
+    "immediately",
+    "now",
+    "urgent",
+    "warning",
+    "act now",
+    "will be",
+    "emergency",
+}
+
+
+def _tokenize(text: str) -> set[str]:
+    return set(re.findall(r"[a-zA-Z']+", text.lower()))
+
+
+def _count_phrase_hits(text: str, terms: Iterable[str]) -> int:
+    lowered = text.lower()
+    hits = 0
+    for term in terms:
+        if term in lowered:
+            hits += 1
+    return hits
+
+
+def _bounded_ratio(hits: int, full_scale_hits: int = 4) -> float:
+    if hits <= 0:
+        return 0.0
+    return min(1.0, hits / float(full_scale_hits))
+
+
+def _sentiment_score(text: str) -> float:
+    tokens = _tokenize(text)
+    pos = len(tokens & POSITIVE_TERMS)
+    neg = len(tokens & NEGATIVE_TERMS)
+    total = pos + neg
+    if total == 0:
+        return 0.0
+    return max(-1.0, min(1.0, (pos - neg) / total))
+
+
+def _actionability_label(
+    war: float,
+    oil: float,
+    sanctions: float,
+    urgency: float,
+    chokepoint: float,
+    kinetic: float,
+    policy: float,
+    execution: float,
+) -> str:
+    composite = (
+        max(war, oil, sanctions, chokepoint, kinetic, policy) * 0.6
+        + urgency * 0.2
+        + execution * 0.2
+    )
+    if composite >= 0.6:
+        return "high"
+    if composite >= 0.2:
+        return "medium"
+    return "low"
+
+
+def extract_indicators(text: str) -> dict:
+    lowered = text.lower()
+
+    war_hits = _count_phrase_hits(text, WAR_ESCALATION_TERMS)
+    oil_hits = _count_phrase_hits(text, OIL_SUPPLY_RISK_TERMS)
+    sanctions_hits = _count_phrase_hits(text, SANCTIONS_TERMS)
+    urgency_hits = _count_phrase_hits(text, URGENCY_TERMS)
+
+    chokepoint_hits = _count_phrase_hits(text, CHOKEPOINT_TERMS)
+    kinetic_hits = _count_phrase_hits(text, KINETIC_ACTION_TERMS)
+    policy_hits = _count_phrase_hits(text, POLICY_MECHANISM_TERMS)
+    execution_hits = _count_phrase_hits(text, EXECUTION_CERTAINTY_TERMS)
+
+    war_score = _bounded_ratio(war_hits)
+    oil_score = _bounded_ratio(oil_hits)
+    sanctions_score = _bounded_ratio(sanctions_hits, full_scale_hits=3)
+    urgency_score = _bounded_ratio(urgency_hits, full_scale_hits=3)
+
+    chokepoint_score = _bounded_ratio(chokepoint_hits, full_scale_hits=4)
+    kinetic_score = _bounded_ratio(kinetic_hits, full_scale_hits=4)
+    policy_score = _bounded_ratio(policy_hits, full_scale_hits=4)
+    execution_score = _bounded_ratio(execution_hits, full_scale_hits=3)
+
+    sentiment = _sentiment_score(text)
+
+    actionability = _actionability_label(
+        war_score,
+        oil_score,
+        sanctions_score,
+        urgency_score,
+        chokepoint_score,
+        kinetic_score,
+        policy_score,
+        execution_score,
+    )
+
+    return {
+        "sentiment_score": sentiment,
+        "war_escalation_score": war_score,
+        "oil_supply_risk_score": oil_score,
+        "sanctions_score": sanctions_score,
+        "urgency_score": urgency_score,
+        "chokepoint_risk_score": chokepoint_score,
+        "kinetic_action_score": kinetic_score,
+        "policy_mechanism_score": policy_score,
+        "execution_certainty_score": execution_score,
+        "actionability": actionability,
+        "matched_terms": {
+            "war_escalation": [t for t in sorted(WAR_ESCALATION_TERMS) if t in lowered],
+            "oil_supply_risk": [t for t in sorted(OIL_SUPPLY_RISK_TERMS) if t in lowered],
+            "sanctions": [t for t in sorted(SANCTIONS_TERMS) if t in lowered],
+            "urgency": [t for t in sorted(URGENCY_TERMS) if t in lowered],
+            "chokepoint_risk": [t for t in sorted(CHOKEPOINT_TERMS) if t in lowered],
+            "kinetic_action": [t for t in sorted(KINETIC_ACTION_TERMS) if t in lowered],
+            "policy_mechanism": [t for t in sorted(POLICY_MECHANISM_TERMS) if t in lowered],
+            "execution_certainty": [t for t in sorted(EXECUTION_CERTAINTY_TERMS) if t in lowered],
+        },
+    }

--- a/src/truthbrush_oil_study/report.py
+++ b/src/truthbrush_oil_study/report.py
@@ -2,6 +2,23 @@ from __future__ import annotations
 
 import pandas as pd
 
+from .indicators import extract_indicators
+
+
+INDICATOR_COLUMNS = [
+    "sentiment_score",
+    "war_escalation_score",
+    "oil_supply_risk_score",
+    "sanctions_score",
+    "urgency_score",
+    "chokepoint_risk_score",
+    "kinetic_action_score",
+    "policy_mechanism_score",
+    "execution_certainty_score",
+    "actionability",
+    "matched_terms",
+]
+
 
 def summarize_event_study(df: pd.DataFrame) -> pd.DataFrame:
     if df.empty:
@@ -23,4 +40,24 @@ def add_significance_flags(summary: pd.DataFrame, alpha: float = 0.05) -> pd.Dat
     if "p_value" not in out.columns:
         out["p_value"] = pd.NA
     out["is_significant"] = out["p_value"].apply(lambda p: bool(p < alpha) if pd.notna(p) else False)
+    return out
+
+
+def enrich_events_with_indicators(df: pd.DataFrame, text_col: str = "text") -> pd.DataFrame:
+    out = df.copy()
+    if text_col not in out.columns:
+        out[text_col] = ""
+
+    indicator_rows = [extract_indicators(str(text or "")) for text in out[text_col].tolist()]
+
+    indicators_df = pd.DataFrame(indicator_rows)
+    if indicators_df.empty:
+        for col in INDICATOR_COLUMNS:
+            if col not in out.columns:
+                out[col] = pd.Series(dtype="object")
+        return out
+
+    for col in INDICATOR_COLUMNS:
+        out[col] = indicators_df.get(col)
+
     return out

--- a/src/truthbrush_oil_study/truth_social.py
+++ b/src/truthbrush_oil_study/truth_social.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 from datetime import datetime, timezone
+from html import unescape
 from typing import Iterable
+from urllib.request import Request, urlopen
+from zoneinfo import ZoneInfo
 
 from dateutil.parser import isoparse
 
@@ -14,6 +18,17 @@ from .models import Post, ThreadContext
 ENV_USERNAME = "TRUTHSOCIAL_USERNAME"
 ENV_PASSWORD = "TRUTHSOCIAL_PASSWORD"
 ENV_TOKEN = "TRUTHSOCIAL_TOKEN"
+TRUMPSTRUTH_URL = "https://trumpstruth.org/"
+TRUMPSTRUTH_TIMEZONE = "America/New_York"
+
+_TRUMPSTRUTH_POST_RE = re.compile(
+    r'href="https://trumpstruth\.org/statuses/(?P<status_id>\d+)"[^>]*>'
+    r'(?P<display_time>[^<]+)</a>.*?'
+    r'href="(?P<orig_url>https://truthsocial\.com/@realDonaldTrump/\d+)"[^>]*>\s*'
+    r'(?:<i[^>]*></i>)?\s*&nbsp;\s*Original Post\s*</a>.*?'
+    r'<div class="status__content"><p>(?P<content>.*?)</p>',
+    re.S,
+)
 
 
 def normalize_post(raw: dict) -> Post:
@@ -41,6 +56,7 @@ def normalize_post(raw: dict) -> Post:
 
 def load_truthsocial_env(base_env: dict[str, str] | None = None) -> dict[str, str]:
     env = dict(base_env or os.environ)
+
     token = env.get(ENV_TOKEN)
     username = env.get(ENV_USERNAME)
     password = env.get(ENV_PASSWORD)
@@ -110,6 +126,53 @@ def fetch_user_statuses(
         for raw_post in _extract_posts_from_page(page):
             posts.append(normalize_post(raw_post))
     return posts
+
+
+def _fetch_trumpstruth_html(url: str) -> str:
+    request = Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urlopen(request, timeout=20) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def _parse_trumpstruth_timestamp(display_time: str) -> datetime:
+    naive = datetime.strptime(display_time.strip(), "%B %d, %Y, %I:%M %p")
+    local_dt = naive.replace(tzinfo=ZoneInfo(TRUMPSTRUTH_TIMEZONE))
+    return local_dt.astimezone(timezone.utc)
+
+
+def _strip_html(fragment: str) -> str:
+    text = re.sub(r"<[^>]+>", " ", fragment)
+    return " ".join(unescape(text).split())
+
+
+def parse_trumpstruth_homepage(html_text: str, *, limit: int | None = None) -> list[Post]:
+    posts: list[Post] = []
+    for match in _TRUMPSTRUTH_POST_RE.finditer(html_text):
+        status_id = match.group("status_id")
+        display_time = match.group("display_time")
+        original_url = match.group("orig_url")
+        content_html = match.group("content")
+        post = Post(
+            id=status_id,
+            created_at=_parse_trumpstruth_timestamp(display_time),
+            text=_strip_html(content_html),
+            url=original_url,
+            raw={
+                "source": "trumpstruth.org",
+                "status_url": f"https://trumpstruth.org/statuses/{status_id}",
+                "display_time": display_time,
+                "original_url": original_url,
+            },
+        )
+        posts.append(post)
+        if limit is not None and len(posts) >= limit:
+            break
+    return posts
+
+
+def fetch_trumpstruth_posts(*, limit: int = 20, url: str = TRUMPSTRUTH_URL) -> list[Post]:
+    html_text = _fetch_trumpstruth_html(url)
+    return parse_trumpstruth_homepage(html_text, limit=limit)
 
 
 def _build_api(env: dict[str, str] | None = None):

--- a/tests/test_backtest_terms.py
+++ b/tests/test_backtest_terms.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pandas as pd
+
+from truthbrush_oil_study.backtest import run_term_indicator_scan
+
+
+def test_run_term_indicator_scan_writes_candidates(tmp_path: Path):
+    out = tmp_path / "run"
+    out.mkdir(parents=True, exist_ok=True)
+
+    posts = pd.DataFrame(
+        [
+            {"date_utc": "2026-04-01", "text": "Hormuz blockade and shipping lane risk"},
+            {"date_utc": "2026-04-02", "text": "No issue today"},
+            {"date_utc": "2026-04-03", "text": "Hormuz tanker route under pressure"},
+            {"date_utc": "2026-04-04", "text": "Hormuz strait closure warning"},
+            {"date_utc": "2026-04-05", "text": "hormuz blockade again"},
+        ]
+    )
+    posts.to_csv(out / "posts_with_indicators.csv", index=False)
+
+    def mk_daily(name: str):
+        days = pd.date_range("2026-03-20", periods=25, freq="D")
+        values = [0.01 + (i % 5) * 0.002 for i in range(25)]
+        df = pd.DataFrame(
+            {
+                "date_utc": days.date.astype(str),
+                "next_abs_return_1d": values,
+            }
+        )
+        # make term days hotter (and non-identical)
+        hot_values = {
+            "2026-04-01": 0.050,
+            "2026-04-03": 0.053,
+            "2026-04-04": 0.056,
+            "2026-04-05": 0.059,
+        }
+        for hot_day, hot_val in hot_values.items():
+            df.loc[df["date_utc"] == hot_day, "next_abs_return_1d"] = hot_val
+        df.to_csv(out / f"{name}_daily_merged.csv", index=False)
+
+    mk_daily("wti")
+    mk_daily("brent")
+
+    summary = run_term_indicator_scan(output_dir=out, min_term_days=4, min_non_term_days=5)
+
+    assert summary["rows"] > 0
+    assert (out / "term_indicator_candidates.csv").exists()

--- a/tests/test_cli_backtest.py
+++ b/tests/test_cli_backtest.py
@@ -1,0 +1,27 @@
+import json
+
+from typer.testing import CliRunner
+
+from truthbrush_oil_study.cli import app
+
+
+runner = CliRunner()
+
+
+def test_backtest_daily_command_outputs_summary_json(monkeypatch):
+    def fake_run_daily_backtest(*, max_pages=60, output_dir=None):
+        return {
+            "run_id": "20260413_000000",
+            "output_dir": "data/backtests/20260413_000000",
+            "posts": 123,
+            "days_with_posts": 40,
+        }
+
+    monkeypatch.setattr("truthbrush_oil_study.cli.run_daily_backtest", fake_run_daily_backtest)
+
+    result = runner.invoke(app, ["backtest-daily", "--max-pages", "5"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["run_id"] == "20260413_000000"
+    assert payload["posts"] == 123

--- a/tests/test_cli_backtest_terms.py
+++ b/tests/test_cli_backtest_terms.py
@@ -1,0 +1,35 @@
+import json
+
+from typer.testing import CliRunner
+
+from truthbrush_oil_study.cli import app
+
+
+runner = CliRunner()
+
+
+def test_backtest_terms_command_outputs_summary_json(monkeypatch):
+    def fake_run_term_indicator_scan(*, output_dir, min_term_days=4, min_non_term_days=30):
+        return {
+            "output_dir": str(output_dir),
+            "rows": 42,
+            "top_term": "hormuz",
+        }
+
+    monkeypatch.setattr("truthbrush_oil_study.cli.run_term_indicator_scan", fake_run_term_indicator_scan)
+
+    result = runner.invoke(
+        app,
+        [
+            "backtest-terms",
+            "--output-dir",
+            "data/backtests/20260413_181242",
+            "--min-term-days",
+            "4",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["rows"] == 42
+    assert payload["top_term"] == "hormuz"

--- a/tests/test_cli_signals.py
+++ b/tests/test_cli_signals.py
@@ -1,0 +1,36 @@
+import json
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+from truthbrush_oil_study.cli import app
+from truthbrush_oil_study.models import Post
+
+
+runner = CliRunner()
+
+
+def test_signals_command_outputs_indicator_records(monkeypatch):
+    sample_post = Post(
+        id="37744",
+        created_at=datetime(2026, 4, 13, 14, 23, tzinfo=timezone.utc),
+        text="Immediate naval blockade in Hormuz. Act now.",
+        url="https://truthsocial.com/@realDonaldTrump/116397847496142849",
+    )
+
+    def fake_fetch(*, limit=5, url="https://trumpstruth.org/"):
+        return [sample_post]
+
+    monkeypatch.setattr("truthbrush_oil_study.cli.fetch_trumpstruth_posts", fake_fetch)
+
+    result = runner.invoke(app, ["signals", "--limit", "1"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert len(payload) == 1
+    assert payload[0]["id"] == "37744"
+    assert payload[0]["actionability"] in {"medium", "high"}
+    assert "chokepoint_risk_score" in payload[0]
+    assert "kinetic_action_score" in payload[0]
+    assert "policy_mechanism_score" in payload[0]
+    assert "execution_certainty_score" in payload[0]

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,64 @@
+from truthbrush_oil_study.indicators import extract_indicators
+
+
+def test_extract_indicators_sentiment_polarity():
+    pos = extract_indicators("Great successful peace deal and strong growth")
+    neg = extract_indicators("Disaster crisis failure and weak economy")
+
+    assert pos["sentiment_score"] > 0
+    assert neg["sentiment_score"] < 0
+
+
+def test_extract_indicators_war_escalation_and_oil_risk():
+    text = "Navy blockade at sea near Hormuz ports. Ships will be eliminated."
+    out = extract_indicators(text)
+
+    assert out["war_escalation_score"] > 0.5
+    assert out["oil_supply_risk_score"] > 0.5
+    assert out["urgency_score"] > 0
+
+
+def test_extract_indicators_sanctions_score():
+    out = extract_indicators("New sanctions and embargo pressure on exports")
+
+    assert out["sanctions_score"] > 0.5
+
+
+def test_extract_indicators_actionability_levels():
+    high = extract_indicators("Immediate naval blockade in Hormuz. Act now.")
+    medium = extract_indicators("Possible sanctions package under discussion.")
+    low = extract_indicators("Happy birthday to everyone. Have a great day.")
+
+    assert high["actionability"] == "high"
+    assert medium["actionability"] in {"medium", "high"}
+    assert low["actionability"] == "low"
+
+
+def test_extract_indicators_new_scores_present_and_bounded():
+    out = extract_indicators(
+        "Strait of Hormuz shipping lane closure likely. "
+        "Naval strike package is ready and effective immediately. "
+        "Sanctions and embargo on exports begin tomorrow."
+    )
+
+    assert "chokepoint_risk_score" in out
+    assert "kinetic_action_score" in out
+    assert "policy_mechanism_score" in out
+    assert "execution_certainty_score" in out
+
+    assert 0.0 <= out["chokepoint_risk_score"] <= 1.0
+    assert 0.0 <= out["kinetic_action_score"] <= 1.0
+    assert 0.0 <= out["policy_mechanism_score"] <= 1.0
+    assert 0.0 <= out["execution_certainty_score"] <= 1.0
+
+
+def test_extract_indicators_chokepoint_kinetic_policy_execution_signal_strength():
+    out = extract_indicators(
+        "Blockade at the Strait of Hormuz. Naval strike operations begin. "
+        "Executive order effective immediately. Sanctions and embargo on oil exports."
+    )
+
+    assert out["chokepoint_risk_score"] >= 0.6
+    assert out["kinetic_action_score"] >= 0.5
+    assert out["policy_mechanism_score"] >= 0.5
+    assert out["execution_certainty_score"] >= 0.5

--- a/tests/test_report_indicators.py
+++ b/tests/test_report_indicators.py
@@ -1,0 +1,38 @@
+import pandas as pd
+
+from truthbrush_oil_study.report import enrich_events_with_indicators
+
+
+def test_enrich_events_with_indicators_adds_indicator_columns():
+    df = pd.DataFrame([
+        {"post_id": "1", "text": "Immediate naval blockade in Hormuz."},
+    ])
+
+    out = enrich_events_with_indicators(df)
+
+    assert "war_escalation_score" in out.columns
+    assert "oil_supply_risk_score" in out.columns
+    assert "chokepoint_risk_score" in out.columns
+    assert "kinetic_action_score" in out.columns
+    assert "policy_mechanism_score" in out.columns
+    assert "execution_certainty_score" in out.columns
+    assert "actionability" in out.columns
+    assert out.loc[0, "actionability"] in {"medium", "high"}
+
+
+def test_enrich_events_with_indicators_handles_empty_df():
+    df = pd.DataFrame(columns=["post_id", "text"])
+
+    out = enrich_events_with_indicators(df)
+
+    assert out.empty
+    assert "actionability" in out.columns
+
+
+def test_enrich_events_with_indicators_handles_missing_text_column():
+    df = pd.DataFrame([{"post_id": "1"}])
+
+    out = enrich_events_with_indicators(df)
+
+    assert "actionability" in out.columns
+    assert out.loc[0, "actionability"] == "low"

--- a/tests/test_trumpstruth_source.py
+++ b/tests/test_trumpstruth_source.py
@@ -1,0 +1,65 @@
+from datetime import timezone
+
+from truthbrush_oil_study import truth_social
+
+
+SAMPLE_HTML = """
+<div class="status-info__meta-item">@realDonaldTrump</a> ·
+  <a href="https://trumpstruth.org/statuses/37744" class="status-info__meta-item">April 13, 2026, 10:23 AM</a>
+</div>
+<div class="status-header__right">
+  <a href="https://truthsocial.com/@realDonaldTrump/116397847496142849" target="_blank" class="status__external-link">
+    <i class="fa-solid fa-arrow-up-right-from-square"></i>&nbsp; Original Post
+  </a>
+</div>
+<div class="status__body">
+  <div class="status__content"><p>Iran’s Navy is laying at the bottom of the sea. <a href="https://example.com/story">Read more</a></p></div>
+</div>
+"""
+
+
+def test_parse_trumpstruth_homepage_extracts_post_fields():
+    posts = truth_social.parse_trumpstruth_homepage(SAMPLE_HTML)
+
+    assert len(posts) == 1
+    post = posts[0]
+    assert post.id == "37744"
+    assert post.url == "https://truthsocial.com/@realDonaldTrump/116397847496142849"
+    assert "Iran’s Navy is laying at the bottom of the sea." in post.text
+    assert post.created_at.tzinfo is not None
+    assert post.created_at.astimezone(timezone.utc).isoformat().startswith("2026-04-13T14:23:00")
+
+
+def test_fetch_trumpstruth_posts_uses_html_fetcher(monkeypatch):
+    monkeypatch.setattr(truth_social, "_fetch_trumpstruth_html", lambda _url: SAMPLE_HTML)
+
+    posts = truth_social.fetch_trumpstruth_posts(limit=1)
+
+    assert len(posts) == 1
+    assert posts[0].id == "37744"
+
+
+def test_fetch_trumpstruth_html_sends_browser_user_agent(monkeypatch):
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b"<html>ok</html>"
+
+    captured = {}
+
+    def fake_urlopen(req, timeout=20):
+        captured["user_agent"] = req.headers.get("User-agent")
+        return FakeResponse()
+
+    monkeypatch.setattr(truth_social, "urlopen", fake_urlopen)
+
+    html = truth_social._fetch_trumpstruth_html("https://trumpstruth.org/")
+
+    assert html == "<html>ok</html>"
+    assert captured["user_agent"]
+    assert "Mozilla" in captured["user_agent"]


### PR DESCRIPTION
## Summary
- add `backtest-daily` CLI command to generate daily volatility backtest artifacts
- add `backtest-terms` CLI command to rank term-level volatility lift from a backtest run
- add expanded indicator set (chokepoint, kinetic, policy, execution certainty) and wire into reporting
- add trumpstruth source parsing/fetch support and associated tests
- ignore generated backtest artifacts under `data/backtests/`

## Validation
- `pytest -q` (full suite)
- `truthbrush-oil-study backtest-daily --max-pages 60`
- `truthbrush-oil-study backtest-terms --output-dir data/backtests/20260413_181242 --min-term-days 4 --min-non-term-days 30`